### PR TITLE
[fix] 디테일 화면 하단 버튼을 눌렀을 때 맞는 전화번호가 뜨게 수정함. [다음에 재수정됨]

### DIFF
--- a/app/src/main/java/com/example/nbc_closer/DetailActivity.kt
+++ b/app/src/main/java/com/example/nbc_closer/DetailActivity.kt
@@ -14,6 +14,7 @@ class DetailActivity : AppCompatActivity() {
     //현재 데이터를 보내고 있어서 해당 데이터는 주석처리 하였습니다.
     //[To-do] MainActivity에서 받은 '클릭된 UserData' 정보를 받아와야 한다. 임시로 값을 clickedUserData에 하드코딩해 주었다.
 //    private val clickedUserData = UserData(R.drawable.user_img_yujin, "안유진", "bluecar@naver.com","010-9874-3216",false)
+    //초기 뷰 설정 관련 메소드
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,9 +30,10 @@ class DetailActivity : AppCompatActivity() {
             3. 받아온 값을 암시적 intent로 외부에 보내 문자/통화
         */
 
+
     }
 
-    //초기 뷰 설정 관련 메소드
+    //bundle로 수정
     private fun initView(){
         detailData = intent.getParcelableExtra<UserData>("detail")!!
         if(detailData.img == -1){
@@ -44,6 +46,13 @@ class DetailActivity : AppCompatActivity() {
         binding.detailEmail.text = detailData.email
         binding.detailNumber.text = detailData.number
         binding.detailToolBar.title = ""
+
+        //bundle 포장 시작
+        var detailFragment = DetailButtonBarFragment()
+        var numberBundle = Bundle()
+        numberBundle.putString("number", detailData.number)
+        detailFragment.arguments = numberBundle
+        //bundle 포장 끝
     }
     // 뒤로 가기 기능 설정, intent 사용하지 않고 액티비티 finish() 처리하였습니다.
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/app/src/main/java/com/example/nbc_closer/DetailButtonBarFragment.kt
+++ b/app/src/main/java/com/example/nbc_closer/DetailButtonBarFragment.kt
@@ -11,7 +11,13 @@ import androidx.fragment.app.Fragment
 import com.example.nbc_closer.databinding.FragmentDetailButtonBarBinding
 
 class DetailButtonBarFragment: Fragment() {
-    private var detailPhoneNumber = "010-9874-3216" // 나중에 가지고 와야.
+
+    //DetailActivity에서 여기로 번호를 가져와야 함.
+    //Activity에서 번들 사용해서 가져오면 됨! <<< index 찝기
+
+    //번들 받기 시작
+    private var detailPhoneNumber = arguments?.getString("number")
+    //번들 받기 끝
     private val binding by lazy {FragmentDetailButtonBarBinding.inflate(layoutInflater)}
 
     override fun onCreateView(


### PR DESCRIPTION
[feat] 번들로 감싸 전화번호 정보를 보냄!
DetailActivity.kt -> DetailButtonBarFragment.kt

Activity/Fragment ==> Fragment : 번들 사용.
1) 이동할 Fragment 객체 생성
2) Bundle 객체 생성 및 데이터 저장 
→ bundle.putXXXX(name, value)
3) Fragment객체.arguments = Bundle객체

//DetailActivity.kt onCreate { initView() } 내 코드
    var detailFragment = DetailButtonBarFragment()
    var numberBundle = Bundle()
    numberBundle.putString("number", detailData.number)
    detailFragment.arguments = numberBundle
    
//DetailButtonBarFragment.kt 내 코드
    private var detailPhoneNumber = 
    arguments?.getString("number")

참고 블로그: https://velog.io/@jinny_0422/Android-Fragment-Activity간-데이터전달