### PR TITLE
[fix] 디테일 페이지 버튼을 눌렀을 때 인텐트로 전화번호가 전달되지 않고 null값이 뜨는 현상 해결

### DIFF
--- a/app/src/main/java/com/example/nbc_closer/DetailActivity.kt
+++ b/app/src/main/java/com/example/nbc_closer/DetailActivity.kt
@@ -1,8 +1,11 @@
 package com.example.nbc_closer
 
 import android.os.Bundle
+import android.util.Log
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
 import com.example.nbc_closer.databinding.ActivityDetailBinding
 
 class DetailActivity : AppCompatActivity() {
@@ -52,7 +55,15 @@ class DetailActivity : AppCompatActivity() {
         var detailFragment = DetailButtonBarFragment()
         var numberBundle = Bundle()
         numberBundle.putString("number", detailData.number)
+        Log.d("number", detailData.number)
         detailFragment.arguments = numberBundle
+
+        //프래그먼트 매니저 사용
+        val fragmentManager = supportFragmentManager.beginTransaction()
+        fragmentManager.replace(R.id.detail_btm_bar_frag, detailFragment)
+        fragmentManager.commit()
+        //프래그먼트 매니저 사용
+
         //bundle 포장 끝
     }
     // 뒤로 가기 기능 설정, intent 사용하지 않고 액티비티 finish() 처리하였습니다.

--- a/app/src/main/java/com/example/nbc_closer/DetailButtonBarFragment.kt
+++ b/app/src/main/java/com/example/nbc_closer/DetailButtonBarFragment.kt
@@ -3,6 +3,7 @@ package com.example.nbc_closer
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -15,17 +16,24 @@ class DetailButtonBarFragment: Fragment() {
     //DetailActivity에서 여기로 번호를 가져와야 함.
     //Activity에서 번들 사용해서 가져오면 됨! <<< index 찝기
 
-    //번들 받기 시작
-    private var detailPhoneNumber = arguments?.getString("number")
     //번들 받기 끝
     private val binding by lazy {FragmentDetailButtonBarBinding.inflate(layoutInflater)}
 
-    override fun onCreateView(
+    override fun onCreateView( //
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         //detail 페이지에서 외부 문자, 전화 앱으로 이동
+        //번들 받기 시작
+        val detailPhoneNumber = arguments?.getString("number")
+        Log.d("number2",
+            detailPhoneNumber.toString()) //.toString()
         binding.detailMessageBtn.setOnClickListener {
             val messageIntent = Intent( Intent.ACTION_SENDTO, Uri.parse("sms:" + detailPhoneNumber) )
             startActivity(messageIntent)
@@ -36,8 +44,6 @@ class DetailButtonBarFragment: Fragment() {
             startActivity(callIntent)
             //Toast.makeText(context, "Call", Toast.LENGTH_SHORT).show()
         }//암시적 인텐트 http://developer.android.com/intl/ko/reference/android/content/Intent.html
-
-        return binding.root
     }
 
 }

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -133,11 +133,10 @@
 
         </LinearLayout>
     </ScrollView><!-- [question] elevation과 상관없이(?) xml에서 아래로 갈수록 상단으로 가는 건가? 희한하네. -->
-    <fragment
+    <FrameLayout
         android:id="@+id/detail_btm_bar_frag"
         android:layout_width="match_parent"
         android:layout_height="120dp"
-        android:name="com.example.nbc_closer.DetailButtonBarFragment"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### 문제 발생
코드 취합 중, Activity -> Fragment로 보낸 Bundle argument 출력값이 null로 나오는 현상 발생.

![스크린샷 2024-04-26 132611](https://github.com/NBC-Project-closer/Closer/assets/75528131/c7091166-22c2-4c75-a83f-4205017822bb)

### 해결 과정

0. activity_detail.xml 상의 Fragment 위젯을 FrameLayout으로 바꾸고, 아래 코드를 삭제함.    `android:name="com.example.nbc_closer.DetailButtonBarFragment"`
(레이아웃 형식 중요X, Fragment를 XML 상에서 바로 name으로 부르게 하지 않기 위함)

1. DetailActivity.kt에서 fragmentManager를 사용
```
val fragmentManager = supportFragmentManager.beginTransaction()
fragmentManager.replace(R.id.detail_btm_bar_frag, detailFragment)
fragmentManager.commit()
```
참고 사항: 이전 버전의 FragmentTransaction()은 API 28부터 deprecated된 메소드.
[새로운 FragmentTransaction](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction.html)에서는 예시 코드처럼 beginTransaction()을 사용해야 함.